### PR TITLE
Improve summary table styling

### DIFF
--- a/sale_report.xml
+++ b/sale_report.xml
@@ -173,11 +173,20 @@
             <t t-set="sum_volumes" t-value="sum(line.line_packing_volumes for line in doc.order_line)"/>
             <t t-set="sum_weight" t-value="sum(line.line_packing_weight for line in doc.order_line)"/>
             <t t-set="sum_cubicagem" t-value="sum(line.line_packing_cubicagem for line in doc.order_line)"/>
-            <table class="table table-borderless table-sm mt-2">
+            <table class="table table-sm table-bordered small rounded w-100 mt-2">
+                <thead class="table-light">
+                    <tr>
+                        <th colspan="3" class="text-center">Summary</th>
+                    </tr>
+                </thead>
                 <tbody>
                     <tr>
                         <th>Total Volumes</th>
                         <td class="text-end"><span t-out="sum_volumes"/></td>
+                        <td class="align-top" rowspan="3">
+                            <div t-field="doc.partner_shipping_id" t-options="{&quot;widget&quot;: &quot;contact&quot;, &quot;fields&quot;: [&quot;address&quot;, &quot;name&quot;, &quot;phone&quot;], &quot;no_marker&quot;: True, &quot;phone_icons&quot;: True}"/>
+                            <span t-field="doc.x_studio_imagem_paletes" t-options="{&quot;widget&quot;: &quot;image&quot;}" class="d-block mt-1" t-att-style="'max-width:150px;'"/>
+                        </td>
                     </tr>
                     <tr>
                         <th>Total Peso (Kg)</th>
@@ -186,16 +195,6 @@
                     <tr>
                         <th>Total Cubicagem</th>
                         <td class="text-end"><span t-out="sum_cubicagem"/></td>
-                    </tr>
-                    <tr>
-                        <th>Shipping Address</th>
-                        <td>
-                            <div t-field="doc.partner_shipping_id" t-options="{&quot;widget&quot;: &quot;contact&quot;, &quot;fields&quot;: [&quot;address&quot;, &quot;name&quot;, &quot;phone&quot;], &quot;no_marker&quot;: True, &quot;phone_icons&quot;: True}"/>
-                        </td>
-                    </tr>
-                    <tr>
-                        <th>Imagem Paletes</th>
-                        <td><span t-field="doc.x_studio_imagem_paletes" t-options="{&quot;widget&quot;: &quot;image&quot;}"/></td>
                     </tr>
                 </tbody>
             </table>


### PR DESCRIPTION
## Summary
- adjust the packing summary table with bootstrap classes
- center and title the summary section
- place totals in a left column and move shipping details and image to the right
- shrink the paletes image and stretch the table width

## Testing
- `grep -n "table-sm" -n sale_report.xml`


------
https://chatgpt.com/codex/tasks/task_b_685aaa794c6083238c82ebd9c705b24a