### PR TITLE
Improve summary table styling

### DIFF
--- a/sale_report.xml
+++ b/sale_report.xml
@@ -173,11 +173,25 @@
             <t t-set="sum_volumes" t-value="sum(line.line_packing_volumes for line in doc.order_line)"/>
             <t t-set="sum_weight" t-value="sum(line.line_packing_weight for line in doc.order_line)"/>
             <t t-set="sum_cubicagem" t-value="sum(line.line_packing_cubicagem for line in doc.order_line)"/>
-            <table class="table table-borderless table-sm mt-2">
+            <table class="table table-sm table-bordered small rounded w-100 mt-2">
+                <thead class="table-light">
+                    <tr>
+                        <th colspan="3" class="text-center">Summary</th>
+                    </tr>
+                </thead>
                 <tbody>
                     <tr>
                         <th>Total Volumes</th>
                         <td class="text-end"><span t-out="sum_volumes"/></td>
+                        <td class="align-top" rowspan="3">
+                            <div t-field="doc.partner_shipping_id" t-options="{&quot;widget&quot;: &quot;contact&quot;, &quot;fields&quot;: [&quot;address&quot;, &quot;name&quot;, &quot;phone&quot;], &quot;no_marker&quot;: True, &quot;phone_icons&quot;: True}"/>
+                            <span t-field="doc.payment_ter_id" class="d-block mt-1"/>
+                            <div class="small">
+                                Production lead time: 8 - 10 weeks after deposit of 40% of the order value<br/>
+                                Prices in Euros, ex-works Porto - Portugal, without taxes.
+                            </div>
+                            <span t-field="doc.x_studio_imagem_paletes" t-options="{&quot;widget&quot;: &quot;image&quot;}" class="d-block mt-1" t-att-style="'max-width:150px;'"/>
+                        </td>
                     </tr>
                     <tr>
                         <th>Total Peso (Kg)</th>
@@ -187,18 +201,18 @@
                         <th>Total Cubicagem</th>
                         <td class="text-end"><span t-out="sum_cubicagem"/></td>
                     </tr>
-                    <tr>
-                        <th>Shipping Address</th>
-                        <td>
-                            <div t-field="doc.partner_shipping_id" t-options="{&quot;widget&quot;: &quot;contact&quot;, &quot;fields&quot;: [&quot;address&quot;, &quot;name&quot;, &quot;phone&quot;], &quot;no_marker&quot;: True, &quot;phone_icons&quot;: True}"/>
-                        </td>
-                    </tr>
-                    <tr>
-                        <th>Imagem Paletes</th>
-                        <td><span t-field="doc.x_studio_imagem_paletes" t-options="{&quot;widget&quot;: &quot;image&quot;}"/></td>
-                    </tr>
                 </tbody>
             </table>
+            <div class="row small">
+                <div class="col-6">
+                    Swift code BCOMPTPL: IBAN PT50 0033 0000 00273554648 05<br/>
+                    Swift code TOTAPTPL: IBAN PT50 0018 2168 02404506020 13
+                </div>
+                <div class="col-6 text-end">
+                    Advanced payment by bank transfer.<br/>
+                    Please refer to our General Conditions of Sales.
+                </div>
+            </div>
             <div class="oe_structure"/>
         </div>
     </t>


### PR DESCRIPTION
## Summary
- adjust the packing summary table with bootstrap classes
- center and title the summary section
- place totals in a left column and move shipping details and image to the right
- shrink the paletes image and stretch the table width
- add bank details and payment note below the summary
- show payment term and lead time information

## Testing
- `grep -n "table-sm" -n sale_report.xml`


------
https://chatgpt.com/codex/tasks/task_b_685aaa794c6083238c82ebd9c705b24a