### PR TITLE
Clean product name in sale report

### DIFF
--- a/sale_report.xml
+++ b/sale_report.xml
@@ -105,7 +105,7 @@
 
                         <tr t-att-class="'fw-bold o_line_section' if (                                 line.display_type == 'line_section'                                 or line.product_type == 'combo'                             )                             else 'fst-italic o_line_note' if line.display_type == 'line_note'                             else ''">
                             <t t-if="not line.display_type and line.product_type != 'combo'"><td name="td_name">
-    <span t-out="line.name.split('(')[0].replace(':', '').strip()"/>
+    <span t-out="__import__('re').sub(r'\([^)]*\)', '', line.name).replace(':', ' ').strip()"/>
 </td>
                                 <td name="td_quantity" class="text-end text-nowrap"><span t-field="line.product_uom_qty">3</span> <span t-field="line.product_uom">units</span>
                                     <span t-if="line.product_packaging_id">


### PR DESCRIPTION
## Summary
- sanitize product name by removing parentheses and replacing colons with spaces

## Testing
- `pytest -q`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_685c05e401448323bde58a22e68b88ee