### PR TITLE
Fix sale to purchase link counters

### DIFF
--- a/pg_sale_purchase_link/models/__init__.py
+++ b/pg_sale_purchase_link/models/__init__.py
@@ -1,1 +1,2 @@
 from . import sale_order
+

--- a/pg_sale_purchase_link/models/sale_order.py
+++ b/pg_sale_purchase_link/models/sale_order.py
@@ -8,24 +8,28 @@ class SaleOrder(models.Model):
     _inherit = 'sale.order'
 
     purchase_order_count = fields.Integer(
-        string='Purchase Order Count',
-        compute='_compute_purchase_order_count',
-        store=True
+        string="Purchase Order Count",
+        compute="_compute_purchase_order_count",
     )
 
     mrp_production_count = fields.Integer(
         compute="_compute_mrp_production_count",
-        store=True
     )
 
-    @api.depends('state')  # safer: recompute after confirmation, when name is final
+    @api.depends('procurement_group_id')
     def _compute_purchase_order_count(self):
+        """Count purchase orders linked by procurement group."""
         for order in self:
-            if order.name:
-                count = self.env['purchase.order'].search_count([
-                    ('origin', '=', order.name)
-                ])
-                _logger.info("[DEBUG] Found %s POs for sale order %s", count, order.name)
+            group = order.procurement_group_id
+            if group:
+                domain = [('group_id', '=', group.id)]
+                count = self.env['purchase.order'].search_count(domain)
+                _logger.debug(
+                    "Found %s purchase orders for SO %s via group %s",
+                    count,
+                    order.name,
+                    group.id,
+                )
                 order.purchase_order_count = count
             else:
                 order.purchase_order_count = 0
@@ -37,18 +41,24 @@ class SaleOrder(models.Model):
             'name': 'Purchase Orders',
             'res_model': 'purchase.order',
             'view_mode': 'list,form',
-            'domain': [('origin', '=', self.name)],
+            'domain': [('group_id', '=', self.procurement_group_id.id)],
             'context': {'create': False},
         }
 
-    @api.depends('state')  # triggers after confirmation
+    @api.depends('procurement_group_id')
     def _compute_mrp_production_count(self):
+        """Count manufacturing orders linked by procurement group."""
         for order in self:
-            if order.name:
-                mo_count = self.env['mrp.production'].search_count([
-                    ('origin', 'ilike', order.name)
-                ])
-                _logger.info("[DEBUG] Found %s MOs for sale order %s", mo_count, order.name)
+            group = order.procurement_group_id
+            if group:
+                domain = [('procurement_group_id', '=', group.id)]
+                mo_count = self.env['mrp.production'].search_count(domain)
+                _logger.debug(
+                    "Found %s manufacturing orders for SO %s via group %s",
+                    mo_count,
+                    order.name,
+                    group.id,
+                )
                 order.mrp_production_count = mo_count
             else:
                 order.mrp_production_count = 0
@@ -60,7 +70,21 @@ class SaleOrder(models.Model):
             'name': 'Manufacturing Orders',
             'res_model': 'mrp.production',
             'view_mode': 'list,form',
-            'domain': [('origin', 'ilike', self.name)],
+            'domain': [('procurement_group_id', '=', self.procurement_group_id.id)],
             'context': {'create': False},
         }
+
+    def action_confirm(self):
+        old_names = {order.id: order.name for order in self}
+        res = super().action_confirm()
+        for order in self:
+            old_name = old_names.get(order.id)
+            new_name = order.name
+            if old_name and new_name and old_name != new_name:
+                purchases = self.env['purchase.order'].search([
+                    ('origin', '=', old_name)
+                ])
+                if purchases:
+                    purchases.write({'origin': new_name})
+        return res
 


### PR DESCRIPTION
## Summary
- fix computed purchase/manufacturing order counts using procurement group
- update smart button domains accordingly
- keep purchase link when sale order name changes

## Testing
- `python -m py_compile pg_sale_purchase_link/models/sale_order.py pg_sale_purchase_link/models/__init__.py`


------
https://chatgpt.com/codex/tasks/task_b_685c128cbe3c8323a41a5431678e1984