### PR TITLE
Add automation to update MO group from SO

### DIFF
--- a/pg_sale_purchase_link/models/__init__.py
+++ b/pg_sale_purchase_link/models/__init__.py
@@ -1,2 +1,4 @@
 from . import sale_order
 
+from . import mrp_production
+

--- a/pg_sale_purchase_link/models/mrp_production.py
+++ b/pg_sale_purchase_link/models/mrp_production.py
@@ -1,0 +1,23 @@
+from odoo import models, api
+
+
+class MrpProduction(models.Model):
+    _inherit = 'mrp.production'
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        for record, vals in zip(records, vals_list):
+            record._update_procurement_group_from_sale()
+        return records
+
+    def _update_procurement_group_from_sale(self):
+        for production in self:
+            if not production.origin:
+                continue
+            sale_order = self.env['sale.order'].search([
+                ('name', '=', production.origin)
+            ], limit=1)
+            if sale_order:
+                production.procurement_group_id = sale_order.procurement_group_id.id
+


### PR DESCRIPTION
## Summary
- automate MRP production creation so its procurement group matches the sale order it originated from

## Testing
- `python -m py_compile pg_sale_purchase_link/models/mrp_production.py`
- `python -m py_compile pg_sale_purchase_link/models/__init__.py pg_sale_purchase_link/models/sale_order.py`
- `python -m py_compile pg_sale_purchase_link/__manifest__.py pg_packing_list/models/product_template.py pg_packing_list/models/sale_order.py pg_packing_list/models/stock_picking.py`


------
https://chatgpt.com/codex/tasks/task_b_685c1ad015948323bc26cd4850e8dbb6